### PR TITLE
Allow to use bootstrap 3.X.X

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "homepage": "https://github.com/koss-lebedev/bootstrap-duration-picker",
   "dependencies": {
-    "bootstrap": "~3.0.0"
+    "bootstrap": "^3.0.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Current configuration requires bootstrap in version: 3.0.X. I think it should be: 3.X.X. (ie. 3.3.7). 